### PR TITLE
INFRA-598 - Support TLS brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Options:
   -b, --broker-url TEXT      URL to the Celery broker.  [env var:
                              CELERY_EXPORTER_BROKER_URL; default:
                              redis://redis:6379/0]
-  --broker-use-ssl           Enable TLS/SSL on the Celery broker
+  -s, --broker-use-ssl       Enable TLS/SSL on the Celery broker
   -l, --listen-address TEXT  Address the HTTPD should listen on.  [env var:
                              CELERY_EXPORTER_LISTEN_ADDRESS; default:
                              0.0.0.0:9540]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Options:
   -b, --broker-url TEXT      URL to the Celery broker.  [env var:
                              CELERY_EXPORTER_BROKER_URL; default:
                              redis://redis:6379/0]
+  --broker-use-ssl           Enable TLS/SSL on the Celery broker
   -l, --listen-address TEXT  Address the HTTPD should listen on.  [env var:
                              CELERY_EXPORTER_LISTEN_ADDRESS; default:
                              0.0.0.0:9540]

--- a/celery_exporter/__main__.py
+++ b/celery_exporter/__main__.py
@@ -25,8 +25,10 @@ LOG_FORMAT = "[%(asctime)s] %(name)s:%(levelname)s: %(message)s"
 )
 @click.option(
     "--broker-use-ssl",
+    "-s",
     is_flag=True,
-    allow_from_autoenv=False,
+    show_default=True,
+    show_envvar=True,
     default=False,
     help="Celery broker use TLS/SSL.",
 )

--- a/celery_exporter/__main__.py
+++ b/celery_exporter/__main__.py
@@ -24,6 +24,13 @@ LOG_FORMAT = "[%(asctime)s] %(name)s:%(levelname)s: %(message)s"
     help="URL to the Celery broker.",
 )
 @click.option(
+    "--broker-use-ssl",
+    is_flag=True,
+    allow_from_autoenv=False,
+    default=False,
+    help="Celery broker use TLS/SSL.",
+)
+@click.option(
     "--listen-address",
     "-l",
     type=str,
@@ -71,6 +78,7 @@ LOG_FORMAT = "[%(asctime)s] %(name)s:%(levelname)s: %(message)s"
 @click.version_option(version=".".join([str(x) for x in __VERSION__]))
 def main(
     broker_url,
+    broker_use_ssl,
     listen_address,
     max_tasks,
     namespace,
@@ -103,6 +111,7 @@ def main(
 
     celery_exporter = CeleryExporter(
         broker_url,
+        broker_use_ssl,
         listen_address,
         max_tasks,
         namespace,

--- a/celery_exporter/core.py
+++ b/celery_exporter/core.py
@@ -15,6 +15,7 @@ class CeleryExporter:
     def __init__(
         self,
         broker_url,
+        broker_use_ssl,
         listen_address,
         max_tasks=10000,
         namespace="celery",
@@ -26,7 +27,7 @@ class CeleryExporter:
         self._namespace = namespace
         self._enable_events = enable_events
 
-        self._app = celery.Celery(broker=broker_url)
+        self._app = celery.Celery(broker=broker_url, broker_use_ssl=broker_use_ssl)
         self._app.conf.broker_transport_options = transport_options or {}
 
     def start(self):


### PR DESCRIPTION
What does this do ?
* [INFRA-598 - RabbitMQ Prometheus Exporters](https://doctorondemand.atlassian.net/browse/INFRA-598)
* Pulls in upstream [OvalMoney/celery-exporter - Added broker-use-ssl flag #24](https://github.com/OvalMoney/celery-exporter/pull/24)
* Adds some enhancements - click ENV var binding

Should merge #1 first.

Local clone setup:
```bash
# Git remote repo from upstream Github repo
git remote add upstream git@github.com:OvalMoney/celery-exporter.git

_git_branch="INFRA-598/support-ssl-02"

# Get upstream PR-24 into a local branch to start with
git fetch upstream "pull/24/head:${_git_branch}"
git checkout "$_git_branch"
```

Local image build for testing:
```bash
make "docker_build"

# tag for ECR celery-exporter
git_sha=$(git rev-parse HEAD)
docker tag "ovalmoney/celery-exporter" "327547205753.dkr.ecr.us-west-2.amazonaws.com/celery-exporter:${git_sha}"

gsts --aws-profile=admin  \                                                   
     --aws-role-arn=arn:aws:iam::327547205753:role/dod/Admin \
     --aws-session-duration 3600

# upload to ECR (using amazon-ecr-credentials-helper from Docker-For-Mac)
AWS_PROFILE=admin docker push "327547205753.dkr.ecr.us-west-2.amazonaws.com/celery-exporter:${git_sha}"
```
* `327547205753.dkr.ecr.us-west-2.amazonaws.com/celery-exporter:427a0f6c8502f314f9fd68e71b0ef5fc75aa5298`
![Screen Shot 2021-01-15 at 4 04 22 PM](https://user-images.githubusercontent.com/70547635/104790105-76123300-574b-11eb-956f-f6414b525540.png)

## Tests
In EC2 on `nonprod-dev-celery-exporter`.

### Fetch Locally built ECR Image in EC2
```bash
gsts --aws-profile=dev \
     --aws-role-arn=arn:aws:iam::327547205753:role/dod/Dev

aws ssm start-sesion ....

# AWS context
ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output "text")
AWS_REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
export AWS_DEFAULT_REGION="$AWS_REGION"

# Authenticate to ECR
aws ecr get-login-password | docker login --username AWS  --password-stdin \
  "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
...
Login Succeeded

# Pull the image we manually pushed to ECR
_tag=427a0f6c8502f314f9fd68e71b0ef5fc75aa5298
docker pull "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/celery-exporter:_tag"
```
### Use Locally Built ECR Image in EC2
```bash
# hack /app/celery-exporter.env
echo "CELERY_EXPORTER_BROKER_USE_SSL=true" >>  /app/celery-exporter.env

export INSTANCE_ID=$(curl -s 169.254.169.254/latest/meta-data/instance-id)
export ContainerName=dev-celery-exporter-exporter

docker run -it --rm --name "$ContainerName" --hostname "$ContainerName-${INSTANCE_ID}" \
 --env-file /app/celery-exporter.env \
  -e AWS_REGION=us-west-2 \
 --net host \
"${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/celery-exporter:$_tag"

[2021-01-16 00:46:25,789] root:INFO: Starting HTTPD on 0.0.0.0:9540
[2021-01-16 00:46:28,304] task-thread:INFO: Start capturing events...
[2021-01-16 00:46:28,328] kombu.mixins:INFO: Connected to amqp://exporter:**@b-0dd78010-454e-465d-a3b6-a7b06e464323.mq.us-west-2.amazonaws.com:5671/dodvhost

```

### Hack Security Groups
* [sg-0a3ca00814c199398](https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#SecurityGroups:group-id=sg-0a3ca00814c199398)
  * 5671 tcp from `sg-0cce318c2b14dbc6b` (dod-backend-nonprod-LegacyCeleryExporterDev-Z90KRGROWRNX-AppResources-8KSKH0XNPQ9Q-AppSecurityGroup-U3YL4ZJJQOZ9)
 
### Confirm It is Listening EC2
Should see the local listening socket and connections from prometheus:
```bash
[root@ip-10-0-20-134 ~]# netstat -anltp | grep 9540
tcp        0      0 0.0.0.0:9540            0.0.0.0:*               LISTEN      7283/python
tcp        0      0 10.0.20.134:9540        10.0.20.51:56700        TIME_WAIT   -
tcp        0      0 10.0.20.134:9540        10.0.20.51:56658        TIME_WAIT   -
tcp        0      0 10.0.20.134:9540        10.0.20.51:56790        TIME_WAIT   -
```
